### PR TITLE
Fixes create_receiver.

### DIFF
--- a/lib/khipu.rb
+++ b/lib/khipu.rb
@@ -8,6 +8,7 @@ require 'khipu/const'
 module Khipu
 
   API_URL = 'https://khipu.com/api/1.3/'
+  INTEGRATOR_API_URL = 'https://khipu.com/integratorApi/1.3/'
   DEBUG = ENV['KHIPU_DEBUG'] || false
   FORM_BUTTONS = {
       '50x25'       => '50x25.png',

--- a/lib/khipu/khipu_api_endpoint.rb
+++ b/lib/khipu/khipu_api_endpoint.rb
@@ -7,12 +7,12 @@ module Khipu
       super(receiver_id, secret)
     end
 
-    def execute(endpoint, params, add_hash = true, json_response = true)
+    def execute(endpoint, params, add_hash = true, json_response = true, base_url = Khipu::API_URL)
       post_params = params.clone
       if add_hash
         post_params['hash'] = hmac_sha256(@secret, concatenated(params))
       end
-      post(endpoint, post_params, json_response)
+      post(endpoint, post_params, json_response, base_url)
     end
 
     def payment_status(args)
@@ -89,28 +89,6 @@ module Khipu
           return_url: args[:return_url] || '',
           cancel_url: args[:cancel_url] || '',
           picture_url: args[:picture_url] || ''
-      }
-      execute(endpoint, params)
-    end
-
-    def create_receiver(args)
-      endpoint = 'createReceiver'
-      check_arguments(args, [:first_name, :last_name, :email, :identifier, :bussiness_category, :bussiness_name,
-                             :phone, :address_line_1, :address_line_2, :address_line_3, :country_code])
-      params = {
-          receiver_id: @receiver_id,
-          first_name: args[:first_name],
-          last_name: args[:last_name],
-          email: args[:email],
-          notify_url: args[:notify_url] || '',
-          identifier: args[:identifier],
-          bussiness_category: args[:bussiness_category],
-          bussiness_name: args[:bussiness_name],
-          phone: args[:phone],
-          address_line_1: args[:address_line_1],
-          address_line_2: args[:address_line_2],
-          address_line_3: args[:address_line_3],
-          country_code: args[:country_code]
       }
       execute(endpoint, params)
     end
@@ -200,7 +178,29 @@ module Khipu
       verify_signature(params, args[:notification_signature])
     end
 
+    # Integrator API
 
+    def create_receiver(args)
+      endpoint = 'createReceiver'
+      check_arguments(args, [:email, :first_name, :last_name, :notify_url, :identifier, :bussiness_category, :bussiness_name,
+                             :phone, :address_line_1, :address_line_2, :address_line_3, :country_code])
+      params = {
+          receiver_id: @receiver_id,
+          email: args[:email],
+          first_name: args[:first_name],
+          last_name: args[:last_name],
+          notify_url: args[:notify_url],
+          identifier: args[:identifier],
+          bussiness_category: args[:bussiness_category],
+          bussiness_name: args[:bussiness_name],
+          phone: args[:phone],
+          address_line_1: args[:address_line_1],
+          address_line_2: args[:address_line_2],
+          address_line_3: args[:address_line_3],
+          country_code: args[:country_code]
+      }
+      execute(endpoint, params, true, true, Khipu::INTEGRATOR_API_URL)
+    end
 
   end
 end

--- a/lib/khipu/khipu_service.rb
+++ b/lib/khipu/khipu_service.rb
@@ -12,8 +12,8 @@ module Khipu
       @secret = secret
     end
 
-    def post(endpoint, params, json_response = true)
-      uri = URI(Khipu::API_URL + endpoint)
+    def post(endpoint, params, json_response = true, base_url = Khipu::API_URL)
+      uri = URI(base_url + endpoint)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       if Khipu::DEBUG

--- a/spec/khipu_api_endpoint_spec.rb
+++ b/spec/khipu_api_endpoint_spec.rb
@@ -30,7 +30,7 @@ describe Khipu::KhipuApiEndpoint do
     subject { api.create_receiver(receiver_params) }
 
     before do
-      stub_request(:post, "https://khipu.com/api/1.3/createReceiver")
+      stub_request(:post, "https://khipu.com/integratorApi/1.3/createReceiver")
       .to_return(body: return_params.to_json)
     end
 


### PR DESCRIPTION
- The integrator API uses a different URL than the regular API calls.
- Rearranges the expected order of params.
- Added notify_url as required.
