### PR TITLE
Fixes to use OpenSSL::Digest.

### DIFF
--- a/lib/khipu/khipu_service.rb
+++ b/lib/khipu/khipu_service.rb
@@ -58,7 +58,7 @@ module Khipu
     end
 
     def hmac_sha256(secret, data)
-      OpenSSL::HMAC.digest(OpenSSL::Digest::Digest.new('sha256'), secret, data).unpack('H*').first
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), secret, data).unpack('H*').first
     end
 
     def concatenated(params)


### PR DESCRIPTION
OpenSSL::Digest::Digest has been discouraged to be used since ruby 1.8.7
(https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51).

And now it's deprecated (https://github.com/ruby/ruby/pull/446).
